### PR TITLE
This should solve troubles building urls, in particular to github

### DIFF
--- a/gitiwiki/modules/gitiwiki/classes/gtwFile.class.php
+++ b/gitiwiki/modules/gitiwiki/classes/gtwFile.class.php
@@ -54,7 +54,11 @@ class gtwFile extends gtwFileBase {
     }
 
     function getPathFileName() {
-        return $this->path.'/'.$this->name;
+        if( $this->path == '' ) {
+            return $this->name;
+        } else {
+            return $this->path.'/'.$this->name;
+        }
     }
 
     function exists() {


### PR DESCRIPTION
As asked by laurentj (https://github.com/jelix/docs-jelix-org/pull/7/files#r1903126) here is a patch to solve troubles while building urls to github. This avoid multiple slashes.

Unit tests still pass (well, it is not worse than before - see https://github.com/laurentj/gitiwiki/issues/6 )
